### PR TITLE
Fix Flaky Test

### DIFF
--- a/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
+++ b/core/src/test/java/org/hibernate/ogm/backendtck/storedprocedures/PositionalParametersStoredProcedureCallTest.java
@@ -151,8 +151,16 @@ public class PositionalParametersStoredProcedureCallTest extends OgmJpaTestCase 
 
 			List<?> listResult = storedProcedureQuery.getResultList();
 			assertThat( listResult ).hasSize( 2 );
-			assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
-			assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
+
+			// assert based on the type of the zeroth element
+			if ( listResult.get( 0 ) instanceof Integer ) {
+				assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 );
+				assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" );
+			}
+			else {
+				assertThat( listResult.get( 0 ) ).isEqualTo( "title'2" );
+				assertThat( ( (Number) listResult.get( 1 ) ).intValue() ).isEqualTo( 2 );
+			}
 		} );
 	}
 


### PR DESCRIPTION


### Description  
Flaky test found using Nondex when running command - 
`mvn -pl neo4j edu.illinois:nondex-maven-plugin:1.1.2:nondex -Dtest=org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest#testResultSetStaticCallRaw`
 The build failure logged was 
`[ERROR] testResultSetStaticCallRaw(org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest)  Time elapsed: 1.943 s  <<< ERROR!
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Number
        at org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest.lambda$testResultSetStaticCallRaw$5(PositionalParametersStoredProcedureCallTest.java:154)
        at org.hibernate.ogm.backendtck.storedprocedures.PositionalParametersStoredProcedureCallTest.testResultSetStaticCallRaw(PositionalParametersStoredProcedureCallTest.java:145)`

### Investigation        
The documentation for `storedProcedureQuery.getResultList()` mentions that the function retrieves the list of results from the next result set. The provider will call `execute` on the query if needed. A `REF_CURSOR` result set, if any, will be retrieved in the order the `REF_CURSOR` parameter was registered with the query. The `execute` query will return true if the first result corresponds to a result set, and false if it is an update count or if there are no results other than through INOUT and OUT parameters, if any. In the given test, the function `setParameter` binds argument values to a positional parameters. The first parameter is void. The object at the 2nd position is an integer and the object at the 3rd position is a string. The getResultList runs an execute before returning a list. The reason for test flakiness is that `storedProcedureQuery.getResultList()` does not preserve the order. The test does not check whether the correct objects are being class casted before using assertions. 
`assertThat( ( (Number) listResult.get( 0 ) ).intValue() ).isEqualTo( 2 ); // It is assumed that the 0th element is going to be an Integer
assertThat( listResult.get( 1 ) ).isEqualTo( "title'2" ); // It is assumed that the 1st element is going to be a string`

### Fixes
To remove the ambiguity, before assertions, the object type of the element in the list is checked to make sure that only Integer is being class casted to Number. 
`listResult.get( 0 ) instanceof Integer`
This fix removes the possibility of ClassCastException and ensures that the test passes. 

